### PR TITLE
feat: add list of tables and list of figures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+
+## 0.3.0
+
+### Features
+- tables of figures/tables: toggle with `show-table-of-figures` and `show-table-of-tables`; optional page breaks via `table-of-figures-page-break` and `table-of-tables-page-break`
+
 ## 0.2.0
 
 

--- a/lib.typ
+++ b/lib.typ
@@ -25,6 +25,8 @@
   show-confidentiality-statement: true,
   show-declaration-of-authorship: true,
   show-table-of-contents: true,
+  show-table-of-figures: true,
+  show-table-of-tables: true,
   show-info-page: false,
   show-abstract: true,
   abstract: none,
@@ -48,6 +50,8 @@
   ignored-link-label-keys-for-highlighting: (),
   abbr-list-csv: "abbr.csv",
   abbr-page-break: true,
+  table-of-figures-page-break: false,
+  table-of-tables-page-break: false,
   pdf-version: "v1.0.0",
   body,
 ) = {
@@ -259,7 +263,7 @@
     )
   }
 
-    // Abbreviations 
+  // Abbreviations 
 
   if abbr-page-break {
     pagebreak()
@@ -274,6 +278,46 @@
   abbr.list()
 
 
+  // Figures
+  show outline.entry.where(level: 1): it => {
+    set block(above: page-grid - body-size)
+    set text(font: heading-font, size: body-size)
+    link(
+      it.element.location(),  // make entry linkable
+      it.indented(
+          it.prefix(),
+          it.body() + "  " +
+            box(width: 1fr, repeat([.], gap: 2pt), baseline: 30%) +
+            "  " + it.page()
+      )
+    )
+  }
+  
+  if(show-table-of-figures){
+    if table-of-figures-page-break {
+      pagebreak()
+    }
+    [= #TABLE_OF_FIGURES.at(language)]
+    outline(
+    title: none, 
+    target: figure.where(kind: image),
+      indent: auto,
+      depth: 3,
+    )
+  }
+  
+  if(show-table-of-tables){
+    if table-of-tables-page-break {
+      pagebreak()
+    }
+    [= #TABLE_OF_TABLES.at(language)]
+    outline(
+    title: none, 
+    target: figure.where(kind: table), //TODO verfiy
+      indent: auto,
+      depth: 3,
+    )
+  }
 
   set page(numbering: "1") // numbering for body body
   in-frontmatter.update(false)  // end of frontmatter

--- a/locale.typ
+++ b/locale.typ
@@ -90,8 +90,18 @@ The content of this thesis may not be made available, either in its entirety or 
 )
 
 #let TABLE_OF_CONTENTS = (
-  "de": "Inhalt",
-  "en": "Contents",
+  "de": "Inhaltsverzeichnis",
+  "en": "Table of Contents",
+)
+
+#let TABLE_OF_FIGURES = (
+  "de": "Bildverzeichnis",
+  "en": "List of Figures",
+)
+
+#let TABLE_OF_TABLES = (
+  "de": "Tabellenverzeichnis",
+  "en": "List of Tables",
 )
 
 #let ABSTRACT = (


### PR DESCRIPTION
This pull request introduces new features to support tables of figures and tables, including configuration options and localized headings. The main changes add toggles and page break controls for these tables, update the document structure to render them, and provide localized labels for their headings.

**New features for tables of figures and tables:**

* Added configuration options `show-table-of-figures`, `show-table-of-tables`, `table-of-figures-page-break`, and `table-of-tables-page-break` to `lib.typ` for toggling and controlling page breaks for tables of figures and tables. [[1]](diffhunk://#diff-bf166bc8404814a5ce7a74196a13bf9acdd01adfbd27c3f83362cec3726895f9R28-R29) [[2]](diffhunk://#diff-bf166bc8404814a5ce7a74196a13bf9acdd01adfbd27c3f83362cec3726895f9R53-R54)
* Updated document rendering logic in `lib.typ` to generate tables of figures and tables based on the new configuration flags, including support for page breaks and outline entries.

**Localization improvements:**

* Added localized labels for "Table of Figures" (`TABLE_OF_FIGURES`) and "Table of Tables" (`TABLE_OF_TABLES`) in `locale.typ`, and updated "Table of Contents" to use more precise terminology.

**Documentation:**

* Documented the new features and configuration options in the `CHANGELOG.md` for version 0.3.0.